### PR TITLE
fix: use absolute spec list to avoid confusion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,17 @@ jobs:
           build: npm run deps
           command: npm run empty
 
+  test-user-spec-list:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout 🛎
+        uses: actions/checkout@v4
+      - name: Split explicit user list of specs 🧪
+        # https://github.com/cypress-io/github-action
+        uses: cypress-io/github-action@v5
+        with:
+          command: npm run user-specs
+
   test-workflow-e2e:
     # https://github.com/bahmutov/cypress-workflows
     uses: bahmutov/cypress-workflows/.github/workflows/split.yml@v1
@@ -125,6 +136,7 @@ jobs:
         test-workflow-e2e,
         test-workflow-component,
         test-no-summary,
+        test-user-spec-list,
       ]
     runs-on: ubuntu-22.04
     steps:

--- a/examples/user-spec-pattern.config.js
+++ b/examples/user-spec-pattern.config.js
@@ -1,0 +1,26 @@
+const { defineConfig } = require('cypress')
+const cypressSplit = require('../src')
+
+module.exports = defineConfig({
+  e2e: {
+    // baseUrl, etc
+    supportFile: false,
+    fixturesFolder: false,
+    excludeSpecPattern: '*.hot-update.js',
+    setupNodeEvents(on, config) {
+      console.log('cwd is', process.cwd())
+
+      // user sets their own custom specPattern list of specs
+      // make sure the list of specs is relative to the folder
+      // with the Cypress config file!
+      config.specPattern = [
+        '../cypress/e2e/spec-c.cy.js',
+        '../cypress/e2e/spec-d.cy.js',
+        '../cypress/e2e/spec-e.cy.js',
+      ]
+      cypressSplit(on, config)
+      // IMPORTANT: return the config object
+      return config
+    },
+  },
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@actions/core": "^1.10.0",
         "console.table": "^0.10.0",
         "debug": "^4.3.4",
-        "find-cypress-specs": "1.35.1",
+        "find-cypress-specs": "1.36.0",
         "humanize-duration": "^3.28.0"
       },
       "devDependencies": {
@@ -3325,9 +3325,9 @@
       }
     },
     "node_modules/find-cypress-specs": {
-      "version": "1.35.1",
-      "resolved": "https://registry.npmjs.org/find-cypress-specs/-/find-cypress-specs-1.35.1.tgz",
-      "integrity": "sha512-ngLPf/U/I8jAS6vn5ljClETa6seG+fmr3oXw6BcYX3xVIk7D8jNljHUIJCTDvnK90XOI1cflYGuNFDezhRBNvQ==",
+      "version": "1.36.0",
+      "resolved": "https://registry.npmjs.org/find-cypress-specs/-/find-cypress-specs-1.36.0.tgz",
+      "integrity": "sha512-D+5xFW8VDCDAzO56gcPWC8w6+AMrW+RfbdYqfhHFr7kMaxQgVibX9Z4qFelHsPbk74hEaoi1HnYZDQ9zncIRxg==",
       "dependencies": {
         "@actions/core": "^1.10.0",
         "arg": "^5.0.1",
@@ -12947,9 +12947,9 @@
       }
     },
     "find-cypress-specs": {
-      "version": "1.35.1",
-      "resolved": "https://registry.npmjs.org/find-cypress-specs/-/find-cypress-specs-1.35.1.tgz",
-      "integrity": "sha512-ngLPf/U/I8jAS6vn5ljClETa6seG+fmr3oXw6BcYX3xVIk7D8jNljHUIJCTDvnK90XOI1cflYGuNFDezhRBNvQ==",
+      "version": "1.36.0",
+      "resolved": "https://registry.npmjs.org/find-cypress-specs/-/find-cypress-specs-1.36.0.tgz",
+      "integrity": "sha512-D+5xFW8VDCDAzO56gcPWC8w6+AMrW+RfbdYqfhHFr7kMaxQgVibX9Z4qFelHsPbk74hEaoi1HnYZDQ9zncIRxg==",
       "requires": {
         "@actions/core": "^1.10.0",
         "arg": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "semantic-release": "semantic-release",
     "demo": "DEBUG=cypress-split,find-cypress-specs SPLIT=2 SPLIT_INDEX=0 cypress run",
     "empty": "DEBUG=cypress-split SPLIT=10 SPLIT_INDEX=9 cypress run",
+    "user-specs": "DEBUG=cypress-split,find-cypress-specs SPLIT=2 SPLIT_INDEX=0 cypress run --config-file examples/user-spec-pattern.config.js",
     "test-names": "find-cypress-specs --names",
     "test-names:component": "find-cypress-specs --component --names",
     "deps": "npm audit --report --omit dev"
@@ -37,7 +38,7 @@
     "@actions/core": "^1.10.0",
     "console.table": "^0.10.0",
     "debug": "^4.3.4",
-    "find-cypress-specs": "1.35.1",
+    "find-cypress-specs": "1.36.0",
     "humanize-duration": "^3.28.0"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -91,8 +91,9 @@ function cypressSplit(on, config) {
 
   if (isDefined(SPLIT) && isDefined(SPLIT_INDEX)) {
     if (!specs) {
+      const returnAbsolute = true
       // @ts-ignore
-      specs = getSpecs(config)
+      specs = getSpecs(config, undefined, returnAbsolute)
     }
 
     console.log('%s there are %d found specs', label, specs.length)


### PR DESCRIPTION
- closes #111 

By returning absolute list of specs, Cypress can always find them