### PR TITLE
Fix typings for `cypressSplit` export

### DIFF
--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -4,7 +4,11 @@ import type Cypress from 'cypress'
  * Initializes the cypress-split plugin using Cypress config values.
  * @see https://github.com/bahmutov/cypress-split
  */
-export default function cypressSplit(
-  on: Cypress.PluginEvents,
-  config: Cypress.PluginConfigOptions,
-): void
+interface CypressSplit {
+  (
+    on: Cypress.PluginEvents,
+    config: Cypress.PluginConfigOptions,
+  ): void;
+}
+declare var cypressSplit: CypressSplit
+export = cypressSplit


### PR DESCRIPTION
The proper way to currently use the library with TypeScript and `esModuleInterop: false` is:
```typescript
import * as cypressSplit from 'cypress-split';

setupNodeEvents(on, config) {
    cypressSplit(on, config);
    return config;
},
```
It works at runtime, but at the same time throws a `TS2349` error because of invalid typings.

This PR fixes the typings so imports are now valid using 1 of these approaches:

`esModuleInterop: false`:
```typescript
import * as cypressSplit from 'cypress-split';
```

`esModuleInterop: true`:
```typescript
import cypressSplit from 'cypress-split';
```