### PR TITLE
fix: Use absolute spec path as result key

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -39,7 +39,7 @@ function cypressSplit(on, config) {
   on('after:spec', (spec, results) => {
     // console.log(results, results)
     debug('after:spec for %s %o', spec.relative, results.stats)
-    specResults[spec.relative] = results
+    specResults[spec.absolute] = results
   })
 
   let SPLIT = process.env.SPLIT || config.env.split || config.env.SPLIT
@@ -113,9 +113,11 @@ function cypressSplit(on, config) {
 
     const addSpecResults = () => {
       specRows.forEach((specRow) => {
-        const specName = specRow[1]
-        const specResult = specResults[specName]
+        const specPath = specRow[1]
+        const specResult = specResults[specPath]
         if (specResult) {
+          const specName = specResult.spec.name
+          specRow[1] = specName
           debug('spec results for %s', specName)
           debug(specResult.stats)
           // have to convert numbers to strings
@@ -125,7 +127,7 @@ function cypressSplit(on, config) {
           specRow.push(String(specResult.stats.skipped))
           specRow.push(humanizeDuration(specResult.stats.wallClockDuration))
         } else {
-          console.error('Could not find spec results for %s', specName)
+          console.error('Could not find spec results for %s', specPath)
         }
       })
     }


### PR DESCRIPTION
This should fix publishing individual spec results to github actions when using specPattern cypress config. Before this change the specResults where using the relative path as object key while the specRows output of the split result was using the absolute paths

I only tested this locally as I could find a quick way to run our cypress tests in https://github.com/nextcloud/text/pull/4847 against a custom patched version of this package. Would be glad to get your feedback about this change.