### PR TITLE
👌 Add OUTPUT_FILE option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,12 +162,25 @@ jobs:
         with:
           command: npm run timings
 
+  test-timings-split-output-file:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout 🛎
+        uses: actions/checkout@v4
+      - name: Split specs based on timings json file 🧪, write output to different file 🗃️
+        # https://github.com/cypress-io/github-action
+        uses: cypress-io/github-action@v5
+        with:
+          command: npm run timings-split-output-file
+      - name: Show split output file
+        run: cat new-timings.json
+
   test-timings-no-file:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout 🛎
         uses: actions/checkout@v4
-      - name: Split specs based on non-existen timings json file 🧪
+      - name: Split specs based on non-existent timings json file 🧪
         # https://github.com/cypress-io/github-action
         uses: cypress-io/github-action@v5
         with:

--- a/README.md
+++ b/README.md
@@ -291,6 +291,18 @@ npx cypress-split-merge \
 
 The above command finds all `timings.json` file in the sub folders of `partials/` folder and merges them. It saved the result to `out-timings.json` file and if running on GitHub Actions sets the job output named `merged-timing` to a stringified single line JSON line.
 
+## Write Timings to a Separate File
+
+You can also indicate where the plugin should output the timings, by setting the `OUTPUT_FILE` environment variable or the corresponding Cypress `env` variable. This will specify the file where the timings will be written. If `OUTPUT_FILE` is not set, the plugin will default to using the same file specified in `SPLIT_FILE`.
+
+```
+# Set the OUTPUT_FILE environment variable
+$ SPLIT_FILE=timings.json OUTPUT_FILE=output.json npx cypress run
+
+# Or use the Cypress --env option
+$ npx cypress run --env splitFile=timings.json,outputFile=output.json
+```
+
 ## CI summary
 
 To skip GitHub Actions summary, set an environment variable `SPLIT_SUMMARY=false`. By default, this plugin generates the summary.

--- a/README.md
+++ b/README.md
@@ -293,11 +293,11 @@ The above command finds all `timings.json` file in the sub folders of `partials/
 
 ## Write Timings to a Separate File
 
-You can also indicate where the plugin should output the timings, by setting the `OUTPUT_FILE` environment variable or the corresponding Cypress `env` variable. This will specify the file where the timings will be written. If `OUTPUT_FILE` is not set, the plugin will default to using the same file specified in `SPLIT_FILE`.
+You can also indicate where the plugin should output the timings, by setting the `SPLIT_OUTPUT_FILE` environment variable or the corresponding Cypress `env` variable. This will specify the file where the timings will be written. If `SPLIT_OUTPUT_FILE` is not set, the plugin will default to using the same file specified in `SPLIT_FILE`.
 
 ```
-# Set the OUTPUT_FILE environment variable
-$ SPLIT_FILE=timings.json OUTPUT_FILE=output.json npx cypress run
+# Set the SPLIT_OUTPUT_FILE environment variable
+$ SPLIT_FILE=timings.json SPLIT_OUTPUT_FILE=output.json npx cypress run
 
 # Or use the Cypress --env option
 $ npx cypress run --env splitFile=timings.json,outputFile=output.json

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "subfolder": "DEBUG=cypress-split,find-cypress-specs SPLIT=2 SPLIT_INDEX=0 cypress run --config-file examples/my-app/tests/cypress.config.js",
     "timings": "DEBUG=cypress-split SPLIT=2 SPLIT_INDEX=0 SPLIT_FILE=timings.json cypress run",
     "timings-no-file": "DEBUG=cypress-split SPLIT=1 SPLIT_INDEX=0 SPLIT_FILE=does-not-exist.json cypress run",
+    "timings-split-output-file": "DEBUG=cypress-split SPLIT=2 SPLIT_INDEX=0 SPLIT_OUTPUT_FILE=new-timings.json SPLIT_FILE=timings.json cypress run",
     "demo-merge": "node ./bin/merge --parent-folder examples/split-times --split-file timings.json --output out-timings.json"
   },
   "repository": {

--- a/src/index.js
+++ b/src/index.js
@@ -89,6 +89,10 @@ function cypressSplit(on, config) {
   let SPLIT = process.env.SPLIT || config.env.split || config.env.SPLIT
   let SPLIT_INDEX = process.env.SPLIT_INDEX || config.env.splitIndex
   let SPLIT_FILE = process.env.SPLIT_FILE || config.env.splitFile
+  let OUTPUT_FILE = process.env.OUTPUT_FILE || config.env.outputFile || SPLIT_FILE
+
+  console.log('Timings are read from %s', SPLIT_FILE)
+  console.log('Files will be outputted to %s', OUTPUT_FILE)
 
   // some CI systems like TeamCity provide agent index starting with 1
   // let's check for SPLIT_INDEX1 and if it is set,
@@ -318,8 +322,8 @@ function cypressSplit(on, config) {
         console.log(timingsString)
 
         if (!foundSplitFile) {
-          console.log('%s writing out timings file %s', label, SPLIT_FILE)
-          fs.writeFileSync(SPLIT_FILE, timingsString + '\n', 'utf8')
+          console.log('%s writing out timings file %s', label, OUTPUT_FILE)
+          fs.writeFileSync(OUTPUT_FILE, timingsString + '\n', 'utf8')
         } else {
           const splitFile = JSON.parse(fs.readFileSync(foundSplitFile, 'utf8'))
           const hasUpdatedTimings = hasTimeDifferences(splitFile, timings, 0.1)
@@ -331,18 +335,22 @@ function cypressSplit(on, config) {
             console.log(
               '%s writing out updated timings file %s',
               label,
-              SPLIT_FILE,
+              OUTPUT_FILE,
             )
             debug('previous timings has %d entries', splitFile.durations.length)
             debug('current timings has %d entries', timings.durations.length)
             debug(
               'merged timings has %d entries written to %s',
               mergedTimings.durations.length,
-              foundSplitFile,
+              OUTPUT_FILE,
             )
-            fs.writeFileSync(foundSplitFile, mergedText + '\n', 'utf8')
+            fs.writeFileSync(OUTPUT_FILE, mergedText + '\n', 'utf8')
           } else {
             console.log('%s spec timings unchanged', label)
+            if(OUTPUT_FILE !== SPLIT_FILE){
+              console.log('%s writing out timings file %s', label, OUTPUT_FILE)
+              fs.writeFileSync(OUTPUT_FILE, timingsString + '\n', 'utf8')
+            }
           }
         }
       }

--- a/src/index.js
+++ b/src/index.js
@@ -91,8 +91,8 @@ function cypressSplit(on, config) {
   let SPLIT_FILE = process.env.SPLIT_FILE || config.env.splitFile
   let SPLIT_OUTPUT_FILE = process.env.SPLIT_OUTPUT_FILE || config.env.outputFile || SPLIT_FILE
 
-  console.log('Timings are read from %s', SPLIT_FILE)
-  console.log('Timings will be written to %s', SPLIT_OUTPUT_FILE)
+  console.log('cypress:split: Timings are read from %s', SPLIT_FILE)
+  console.log('cypress:split: Timings will be written to %s', SPLIT_OUTPUT_FILE)
 
   // some CI systems like TeamCity provide agent index starting with 1
   // let's check for SPLIT_INDEX1 and if it is set,

--- a/src/index.js
+++ b/src/index.js
@@ -92,7 +92,7 @@ function cypressSplit(on, config) {
   let OUTPUT_FILE = process.env.OUTPUT_FILE || config.env.outputFile || SPLIT_FILE
 
   console.log('Timings are read from %s', SPLIT_FILE)
-  console.log('Files will be outputted to %s', OUTPUT_FILE)
+  console.log('Timings will be written to %s', OUTPUT_FILE)
 
   // some CI systems like TeamCity provide agent index starting with 1
   // let's check for SPLIT_INDEX1 and if it is set,

--- a/src/index.js
+++ b/src/index.js
@@ -89,10 +89,10 @@ function cypressSplit(on, config) {
   let SPLIT = process.env.SPLIT || config.env.split || config.env.SPLIT
   let SPLIT_INDEX = process.env.SPLIT_INDEX || config.env.splitIndex
   let SPLIT_FILE = process.env.SPLIT_FILE || config.env.splitFile
-  let OUTPUT_FILE = process.env.OUTPUT_FILE || config.env.outputFile || SPLIT_FILE
+  let SPLIT_OUTPUT_FILE = process.env.SPLIT_OUTPUT_FILE || config.env.outputFile || SPLIT_FILE
 
   console.log('Timings are read from %s', SPLIT_FILE)
-  console.log('Timings will be written to %s', OUTPUT_FILE)
+  console.log('Timings will be written to %s', SPLIT_OUTPUT_FILE)
 
   // some CI systems like TeamCity provide agent index starting with 1
   // let's check for SPLIT_INDEX1 and if it is set,
@@ -322,8 +322,8 @@ function cypressSplit(on, config) {
         console.log(timingsString)
 
         if (!foundSplitFile) {
-          console.log('%s writing out timings file %s', label, OUTPUT_FILE)
-          fs.writeFileSync(OUTPUT_FILE, timingsString + '\n', 'utf8')
+          console.log('%s writing out timings file %s', label, SPLIT_OUTPUT_FILE)
+          fs.writeFileSync(SPLIT_OUTPUT_FILE, timingsString + '\n', 'utf8')
         } else {
           const splitFile = JSON.parse(fs.readFileSync(foundSplitFile, 'utf8'))
           const hasUpdatedTimings = hasTimeDifferences(splitFile, timings, 0.1)
@@ -335,21 +335,21 @@ function cypressSplit(on, config) {
             console.log(
               '%s writing out updated timings file %s',
               label,
-              OUTPUT_FILE,
+              SPLIT_OUTPUT_FILE,
             )
             debug('previous timings has %d entries', splitFile.durations.length)
             debug('current timings has %d entries', timings.durations.length)
             debug(
               'merged timings has %d entries written to %s',
               mergedTimings.durations.length,
-              OUTPUT_FILE,
+              SPLIT_OUTPUT_FILE,
             )
-            fs.writeFileSync(OUTPUT_FILE, mergedText + '\n', 'utf8')
+            fs.writeFileSync(SPLIT_OUTPUT_FILE, mergedText + '\n', 'utf8')
           } else {
             console.log('%s spec timings unchanged', label)
-            if(OUTPUT_FILE !== SPLIT_FILE){
-              console.log('%s writing out timings file %s', label, OUTPUT_FILE)
-              fs.writeFileSync(OUTPUT_FILE, timingsString + '\n', 'utf8')
+            if(SPLIT_OUTPUT_FILE !== SPLIT_FILE){
+              console.log('%s writing out timings file %s', label, SPLIT_OUTPUT_FILE)
+              fs.writeFileSync(SPLIT_OUTPUT_FILE, timingsString + '\n', 'utf8')
             }
           }
         }


### PR DESCRIPTION
I found it useful to have a separate output file for the timings so that I can avoid overriding the SPLIT_FILE with new timings. Thought it would be nice to add it to the main repo