### PR TITLE
Update readme.md with newest cypress github action version

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ strategy:
     containers: [1, 2, 3]
 steps:
   - name: Run split Cypress tests 🧪
-    uses: cypress-io/github-action@v5
+    uses: cypress-io/github-action@v6
     # pass the machine index and the total number
     env:
       SPLIT: ${{ strategy.job-total }}
@@ -439,7 +439,7 @@ for example, if using GitHub Actions:
 
 ```yml
 - name: Run split Cypress tests 🧪
-  uses: cypress-io/github-action@v5
+  uses: cypress-io/github-action@v6
   # pass the machine index and the total number
   env:
     SPLIT: ${{ strategy.job-total }}


### PR DESCRIPTION
Update cypress github action version to the latest major version.

I didnt change the actual .yml files, assuming you will want to test it out on your own before merging PR from a random person on the interwebs :)

I can tell that we have been using cypress-split with cypress github action v6 for couple of weeks and it works good so far.