### PR TITLE
Reproduction and potential solution for issue: "cypress-split always uses average duration" #267

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "timings": "DEBUG=cypress-split SPLIT=2 SPLIT_INDEX=0 SPLIT_FILE=timings.json cypress run",
     "timings-no-file": "DEBUG=cypress-split SPLIT=1 SPLIT_INDEX=0 SPLIT_FILE=does-not-exist.json cypress run",
     "timings-split-output-file": "DEBUG=cypress-split SPLIT=2 SPLIT_INDEX=0 SPLIT_OUTPUT_FILE=new-timings.json SPLIT_FILE=timings.json cypress run",
+    "timings-alternative-config": "SPLIT=2 SPLIT_INDEX=0 SPLIT_FILE=alternative-config-timings.json cypress run --config-file test/alternative-cypress.config.js",
     "demo-merge": "node ./bin/merge --parent-folder examples/split-times --split-file timings.json --output out-timings.json",
     "demo-preview": "node ./bin/preview --split 2",
     "demo-preview-spec": "SPEC=\"cypress/e2e/spec*.cy.js\" node ./bin/preview --split 2",

--- a/src/index.js
+++ b/src/index.js
@@ -172,7 +172,11 @@ function cypressSplit(on, config) {
 
         const specDurations = splitSpecs
           .map((absoluteSpecPath, k) => {
-            const relativeName = specAbsoluteToRelative[absoluteSpecPath]
+            const cwd = process.cwd()
+            const useFix = !!process.env['SPLIT_FIX']
+            const relativeName = useFix
+              ? path.relative(cwd, absoluteSpecPath)
+              : specAbsoluteToRelative[absoluteSpecPath]
             const specResult = specResults[absoluteSpecPath]
             if (specResult) {
               const passed = hasSpecPassed(specResult)

--- a/src/utils.js
+++ b/src/utils.js
@@ -72,9 +72,10 @@ function splitSpecsLogic({ specs, splitN, splitIndex, splitFileName, label }) {
         previousDurations.length
       const specsWithDurations = specs.map((specName) => {
         const relativeSpec = path.relative(cwd, specName)
-        const foundInfo = previousDurations.find(
-          (item) => item.spec === relativeSpec,
-        )
+        const foundInfo = previousDurations.find((item) => {
+          console.log(`Comparing ${item.spec} with ${relativeSpec}`)
+          return item.spec === relativeSpec
+        })
         if (!foundInfo) {
           return {
             specName,

--- a/test/alternative-cypress.config.js
+++ b/test/alternative-cypress.config.js
@@ -1,0 +1,29 @@
+const { defineConfig } = require('cypress')
+const cypressSplit = require('../src')
+
+module.exports = defineConfig({
+  e2e: {
+    // baseUrl, etc
+    supportFile: false,
+    fixturesFolder: false,
+    excludeSpecPattern: '*.hot-update.js',
+    setupNodeEvents(on, config) {
+      cypressSplit(on, config)
+      // IMPORTANT: return the config object
+      return config
+    },
+  },
+
+  component: {
+    devServer: {
+      framework: 'react',
+      bundler: 'vite',
+    },
+    specPattern: 'components/*.cy.js',
+    setupNodeEvents(on, config) {
+      cypressSplit(on, config)
+      // IMPORTANT: return the config object
+      return config
+    },
+  },
+})


### PR DESCRIPTION
To reproduce the issue described in #267 :

1. Run `npm run timings-alternative-config` to generate split file
2. Run `npm run timings-alternative-config` again to see the durations
3. Observe that all durations are equal (average)
![image](https://github.com/bahmutov/cypress-split/assets/24510869/1d660860-cf26-4775-b945-ce83b7cc8163)

To see the fix in action:

1. Run `rm test/alternative-config-timings.json` to remove the timings file, you need to generate it again
2. Run `SPLIT_FIX=true npm run timings-alternative-config` to generate split file using the fix
3. Run `SPLIT_FIX=true npm run timings-alternative-config` again to see the durations
4. Observe that durations are correct
![image](https://github.com/bahmutov/cypress-split/assets/24510869/51de2175-2557-49da-bedb-584188133be5)
