### PR TITLE
fix: incorrect CI count

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -97,7 +97,7 @@ function cypressSplit(on, config) {
       '%s detected %s machine %d of %d',
       label,
       ciName,
-      SPLIT_INDEX,
+      SPLIT_INDEX + 1,
       SPLIT,
     )
   }


### PR DESCRIPTION
Addresses #280. 

The output at the start of the CI job prints the split index in 0-based when the output should be 1-based for readability.

