### PR TITLE
Fix typings for cypressSplit export's third argument

### DIFF
--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -8,6 +8,7 @@ interface CypressSplit {
   (
     on: Cypress.PluginEvents,
     config: Cypress.PluginConfigOptions,
+    userSpecOrderFn?: ((specs: string[]) => string[]) 
   ): void;
 }
 declare var cypressSplit: CypressSplit


### PR DESCRIPTION
The typing for `cypressSplit` export only includes 2 arguments. However in the [docs](https://github.com/bahmutov/cypress-split?tab=readme-ov-file#adjust-the-specs) and [source code ](https://github.com/bahmutov/cypress-split/blob/main/src/index.js#L28) we can add a third argument to modify the spec array if needed.

This PR just updates the typescript definition