### PR TITLE
Fix: round and sort durations after merging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 node_modules/
 cypress/videos
 cypress/screenshots
-out-timings.json

--- a/cypress/e2e/merge-timings.cy.js
+++ b/cypress/e2e/merge-timings.cy.js
@@ -77,3 +77,54 @@ it('takes existing values', () => {
     ],
   })
 })
+
+it('sorts entries', () => {
+  const timings1 = {
+    durations: [
+      {
+        spec: 'cypress/e2e/spec-a.cy.js',
+        duration: 100,
+      },
+      {
+        spec: 'cypress/e2e/spec-c.cy.js',
+        duration: 300,
+      },
+    ],
+  }
+
+  const timings2 = {
+    durations: [
+      {
+        spec: 'cypress/e2e/spec-d.cy.js',
+        duration: 400,
+      },
+      {
+        spec: 'cypress/e2e/spec-b.cy.js',
+        duration: 200,
+      },
+    ],
+  }
+
+  const merged = mergeSplitTimings([timings1, timings2])
+  // the result has sorted entries
+  expect(merged).to.deep.equal({
+    durations: [
+      {
+        spec: 'cypress/e2e/spec-a.cy.js',
+        duration: 100,
+      },
+      {
+        spec: 'cypress/e2e/spec-b.cy.js',
+        duration: 200,
+      },
+      {
+        spec: 'cypress/e2e/spec-c.cy.js',
+        duration: 300,
+      },
+      {
+        spec: 'cypress/e2e/spec-d.cy.js',
+        duration: 400,
+      },
+    ],
+  })
+})

--- a/cypress/e2e/merge-timings.cy.js
+++ b/cypress/e2e/merge-timings.cy.js
@@ -4,7 +4,7 @@ const { mergeSplitTimings } = require('../../src/timings')
 
 chai.config.truncateThreshold = 500
 
-it('averages the durations', () => {
+it('averages and rounds the durations', () => {
   const timings1 = {
     durations: [
       {
@@ -21,7 +21,7 @@ it('averages the durations', () => {
     durations: [
       {
         spec: 'cypress/integration/A.ts',
-        duration: 80,
+        duration: 111,
       },
       {
         spec: 'cypress/integration/B.ts',
@@ -35,7 +35,7 @@ it('averages the durations', () => {
     durations: [
       {
         spec: 'cypress/integration/A.ts',
-        duration: 90,
+        duration: 106,
       },
       {
         spec: 'cypress/integration/B.ts',

--- a/examples/split-times/a/timings.json
+++ b/examples/split-times/a/timings.json
@@ -1,8 +1,12 @@
 {
   "durations": [
     {
-      "spec": "cypress/e2e/spec-b.cy.js",
-      "duration": 10068
+      "spec": "cypress/e2e/spec-a.cy.js",
+      "duration": 100
+    },
+    {
+      "spec": "cypress/e2e/spec-c.cy.js",
+      "duration": 300
     }
   ]
 }

--- a/examples/split-times/b/timings.json
+++ b/examples/split-times/b/timings.json
@@ -1,12 +1,16 @@
 {
   "durations": [
     {
-      "spec": "cypress/e2e/chunks.cy.js",
-      "duration": 230
+      "spec": "cypress/e2e/spec-b.cy.js",
+      "duration": 200
     },
     {
-      "spec": "cypress/e2e/timings.cy.js",
-      "duration": 102
+      "spec": "cypress/e2e/spec-d.cy.js",
+      "duration": 400
+    },
+    {
+      "spec": "cypress/e2e/spec-a.cy.js",
+      "duration": 111
     }
   ]
 }

--- a/examples/split-times/out-timings.json
+++ b/examples/split-times/out-timings.json
@@ -1,0 +1,20 @@
+{
+  "durations": [
+    {
+      "spec": "cypress/e2e/spec-a.cy.js",
+      "duration": 106
+    },
+    {
+      "spec": "cypress/e2e/spec-b.cy.js",
+      "duration": 200
+    },
+    {
+      "spec": "cypress/e2e/spec-c.cy.js",
+      "duration": 300
+    },
+    {
+      "spec": "cypress/e2e/spec-d.cy.js",
+      "duration": 400
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "timings": "DEBUG=cypress-split SPLIT=2 SPLIT_INDEX=0 SPLIT_FILE=timings.json cypress run",
     "timings-no-file": "DEBUG=cypress-split SPLIT=1 SPLIT_INDEX=0 SPLIT_FILE=does-not-exist.json cypress run",
     "timings-split-output-file": "DEBUG=cypress-split SPLIT=2 SPLIT_INDEX=0 SPLIT_OUTPUT_FILE=new-timings.json SPLIT_FILE=timings.json cypress run",
-    "demo-merge": "node ./bin/merge --parent-folder examples/split-times --split-file timings.json --output out-timings.json",
+    "demo-merge": "node ./bin/merge --parent-folder examples/split-times --split-file timings.json --output examples/split-times/out-timings.json",
     "demo-preview": "node ./bin/preview --split 2",
     "demo-preview-spec": "SPEC=\"cypress/e2e/spec*.cy.js\" node ./bin/preview --split 2",
     "demo-preview-shuffle": "SPLIT_RANDOM_SEED=42 node ./bin/preview --split 2",

--- a/src/timings.js
+++ b/src/timings.js
@@ -115,7 +115,7 @@ function mergeSplitTimings(timings, debug = noop) {
       } else {
         // average the durations
         const maxDuration = (item.duration + specResults[item.spec]) / 2
-        specResults[item.spec] = maxDuration
+        specResults[item.spec] = Math.round(maxDuration)
       }
     })
   })

--- a/src/timings.js
+++ b/src/timings.js
@@ -72,6 +72,15 @@ function hasTimeDifferences(
 }
 
 /**
+ * Sort durations by spec file.
+ * @param {object[]} durations Unsorted durations
+ * @returns {object[]} Sorted durations
+ */
+function sortDurations(durations) {
+  return durations.sort((a, b) => a.spec.localeCompare(b.spec))
+}
+
+/**
  * Merge previous timings with possible new or changed timings
  * into a new object to be saved.
  * @param {object} prevTimings JSON loaded from the timings file
@@ -88,7 +97,7 @@ function mergeTimings(prevTimings, currTimings) {
       merged.durations.push(item)
     }
   })
-  merged.durations.sort((a, b) => a.spec.localeCompare(b.spec))
+  merged.durations = sortDurations(merged.durations)
   return merged
 }
 
@@ -129,6 +138,8 @@ function mergeSplitTimings(timings, debug = noop) {
       duration: specResults[spec],
     })
   })
+
+  result.durations = sortDurations(result.durations)
 
   return result
 }


### PR DESCRIPTION
Fixes #349 

Additionally, all durations in the merged file will be sorted by spec name (similar to merging the durations after test execution).

I have updated `exmaples/split-times` and commited `out-timings.json`, so that it's clear what is the expected result of the command.

## Context

My workflow is the following:
- run tests in 5 parallel jobs
- each job saves a file to `cypress/timings/partials/**/input.json`
- after all 5 jobs are complete, I run another job called 'merge timings', where I run `cypress-split-merge` to merge my  `cypress/timings/partials` into a single file `cypress/timings/output.json`

Related to #309 or #284